### PR TITLE
Use Array.isArray instead of isarray package

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@
 
 'use strict';
 
-var isArray = require('isarray');
-
 module.exports = function isObject(val) {
-  return val != null && typeof val === 'object' && isArray(val) === false;
+  return val != null && typeof val === 'object' && Array.isArray(val) === false;
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test": "mocha"
   },
   "dependencies": {
-    "isarray": "1.0.0"
   },
   "devDependencies": {
     "gulp-format-md": "^0.1.9",


### PR DESCRIPTION
The well known [isarray](https://github.com/juliangruber/isarray) package is now deprecated due that the support for Array.isArray is now in all supported browsers.

This PR removes isarray and uses Array.isArray instead.
Fix #6  