### PR TITLE
replaced Array.isArray with isarray package

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@
 
 'use strict';
 
+var isArray = require('isarray');
+
 module.exports = function isObject(val) {
-  return val != null && typeof val === 'object' && Array.isArray(val) === false;
+  return val != null && typeof val === 'object' && !isArray(val);
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   "scripts": {
     "test": "mocha"
   },
-  "dependencies": {},
+  "dependencies": {
+    "isarray": "^2.0.4"
+  },
   "devDependencies": {
     "gulp-format-md": "^0.1.9",
     "mocha": "^2.4.5"


### PR DESCRIPTION
This PR offers better backwards compatibility for environments that don't support `Array.isArray`.

The `isarray` package is the defacto way of performing this type check (46 million monthly downloads) so it makes sense that `isobject` should use it as part of its check.