### PR TITLE
Add esm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ temp
 tmp
 TODO.md
 package-lock.json
+
+ # build
+index.cjs.js

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,5 @@ tmp
 TODO.md
 package-lock.json
 
- # build
+# build
 index.cjs.js

--- a/.verb.md
+++ b/.verb.md
@@ -7,7 +7,7 @@ Use [is-plain-object](https://github.com/jonschlinkert/is-plain-object) if you w
 ## Usage
 
 ```js
-var isObject = require('{%= name %}');
+import isObject from '{%= name %}';
 ```
 
 **True**

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install isobject
 ## Usage
 
 ```js
-var isObject = require('isobject');
+import isObject from 'isobject';
 ```
 
 **True**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-export = isObject;
-
 declare function isObject(val: any): boolean;
 
-declare namespace isObject {}
+export default isObject;

--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@
  * Released under the MIT License.
  */
 
-'use strict';
-
-module.exports = function isObject(val) {
+export default function isObject(val) {
   return val != null && typeof val === 'object' && Array.isArray(val) === false;
 };

--- a/package.json
+++ b/package.json
@@ -18,19 +18,25 @@
   "license": "MIT",
   "files": [
     "index.d.ts",
+    "index.cjs.js",
     "index.js"
   ],
-  "main": "index.js",
+  "main": "index.cjs.js",
+  "module": "index.js",
   "engines": {
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha"
+    "build": "rollup -i index.js -o index.cjs.js -f cjs",
+    "test": "mocha -r esm",
+    "prepublish": "npm run build"
   },
   "dependencies": {},
   "devDependencies": {
+    "esm": "^3.2.22",
     "gulp-format-md": "^0.1.9",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "rollup": "^1.10.1"
   },
   "keywords": [
     "check",

--- a/test.js
+++ b/test.js
@@ -1,8 +1,5 @@
-'use strict';
-
-require('mocha');
-var assert = require('assert');
-var isObject = require('./');
+import assert from 'assert';
+import isObject from './index.js';
 
 it('should be true when the value is an object.', function() {
   assert(isObject({}));


### PR DESCRIPTION
In this diff I converted source code to esm and build cjs from it with
rollup.

Rollup is the only tool which is able generate default export as
`module.exports = lib`.