### PR TITLE
docs: remove duplicate example

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -18,7 +18,6 @@ isObject({});
 isObject(Object.create({}));
 isObject(Object.create(Object.prototype));
 isObject(Object.create(null));
-isObject({});
 isObject(new Foo);
 isObject(/foo/);
 ```


### PR DESCRIPTION
In one example with **true**, two identical examples with a string
```js
isObject({});
```