### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: false
+arch:
+  - amd64
+  - ppc64le
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 # Package             : isobject
 # Source Repo         : https://github.com/jonschlinkert/isobject
 # Travis Job Link     : https://travis-ci.com/github/rajesh-ibm-power/isobject/builds/230576722
-# Created travis.yml  : Yes
+# Created travis.yml  : No
 # Maintainer          : Rajesh kumar <Rajesh.kumar13@ibm.com>
 #
 # Script License      : Apache License, Version 2 or later

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 # ----------------------------------------------------------------------------
 #
-# Package             : jetty-reactive-httpclient 
-# Source Repo         : https://github.com/jetty-project/jetty-reactive-httpclient
-# Travis Job Link     : https://travis-ci.com/github/rajesh-ibm-power/jetty-reactive-httpclient
+# Package             : isobject
+# Source Repo         : https://github.com/jonschlinkert/isobject
+# Travis Job Link     : https://travis-ci.com/github/rajesh-ibm-power/isobject/builds/230576722
 # Created travis.yml  : Yes
 # Maintainer          : Rajesh kumar <Rajesh.kumar13@ibm.com>
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,15 @@
+# ----------------------------------------------------------------------------
+#
+# Package             : jetty-reactive-httpclient 
+# Source Repo         : https://github.com/jetty-project/jetty-reactive-httpclient
+# Travis Job Link     : https://travis-ci.com/github/rajesh-ibm-power/jetty-reactive-httpclient
+# Created travis.yml  : Yes
+# Maintainer          : Rajesh kumar <Rajesh.kumar13@ibm.com>
+#
+# Script License      : Apache License, Version 2 or later
+#
+# ---
+
 sudo: false
 arch:
   - amd64


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The Travis-CI build logs can be verified from the link below.
https://travis-ci.com/github/rajesh-ibm-power/isobject
Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.
Please have a look.

Thank you