### PR TITLE
Update method to check that it's not an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,5 @@
  */
 
 export default function isObject(val) {
-  return val != null && typeof val === 'object' && Array.isArray(val) === false;
+  return val != null && typeof val === 'object' && val.constructor === Array;
 };

--- a/index.js
+++ b/index.js
@@ -6,5 +6,5 @@
  */
 
 export default function isObject(val) {
-  return val != null && typeof val === 'object' && val.constructor === Array;
+  return val != null && typeof val === 'object' && val.constructor !== Array;
 };


### PR DESCRIPTION
According to [jsbench](https://jsben.ch/HVJuT), this method (which checks the constructor of the parameter) performs significantly faster than `Array.isArray()` (I'm on Firefox 84.0.2, 64-bit)

![image](https://user-images.githubusercontent.com/42120904/104080089-f29c9300-51da-11eb-92eb-e0642f3aaa63.png)
![image](https://user-images.githubusercontent.com/42120904/104080082-e9132b00-51da-11eb-969d-1c0577e4b48f.png)
![image](https://user-images.githubusercontent.com/42120904/104080087-edd7df00-51da-11eb-9acc-0c3e6d45bfaa.png)
![image](https://user-images.githubusercontent.com/42120904/104080054-caad2f80-51da-11eb-9974-8afe624ea200.png)
