### PR TITLE
More strict null comparision

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,5 @@
  */
 
 export default function isObject(val) {
-  return val != null && typeof val === 'object' && Array.isArray(val) === false;
+  return val !== null && typeof val === 'object' && Array.isArray(val) === false;
 };


### PR DESCRIPTION
Since `typeof undefined` returns `undefined`... why dont make more strinct null comparision just to make it easier to read?

(It was new to me that `null != undefined` return `true`)