### PR TITLE
Type predicate for easier type checking

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
-declare function isObject(val: any): boolean;
+declare function isObject(val: any): val is { [key: string]: unknown };
 
 export default isObject;


### PR DESCRIPTION
PR to address my complaint in issue #27. Instead of the return type being true or false, the function should return if the value is a object or not.